### PR TITLE
Align package version source

### DIFF
--- a/ke2daira/__init__.py
+++ b/ke2daira/__init__.py
@@ -1,17 +1,7 @@
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import version
 
 from .main import ke2dairanize
 
+__version__ = version("ke2daira")
+
 __all__ = ["__version__", "ke2dairanize"]
-
-
-def __getattr__(name: str) -> str:
-    if name != "__version__":
-        msg = f"module {__name__!r} has no attribute {name!r}"
-        raise AttributeError(msg)
-
-    try:
-        return version("ke2daira")
-    except PackageNotFoundError as exc:
-        msg = "Package metadata for 'ke2daira' is unavailable."
-        raise RuntimeError(msg) from exc

--- a/ke2daira/__init__.py
+++ b/ke2daira/__init__.py
@@ -1,5 +1,17 @@
+from importlib.metadata import PackageNotFoundError, version
+
 from .main import ke2dairanize
 
-__version__ = "0.2.0"
+__all__ = ["__version__", "ke2dairanize"]
 
-__all__ = ["ke2dairanize"]
+
+def __getattr__(name: str) -> str:
+    if name != "__version__":
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg)
+
+    try:
+        return version("ke2daira")
+    except PackageNotFoundError as exc:
+        msg = "Package metadata for 'ke2daira' is unavailable."
+        raise RuntimeError(msg) from exc

--- a/tests/test_ke2daira.py
+++ b/tests/test_ke2daira.py
@@ -1,11 +1,13 @@
 # ruff: noqa: S101
+from importlib.metadata import version
+
 import pytest
 
 from ke2daira import __version__, ke2dairanize
 
 
 def test_version() -> None:
-    assert __version__ == "0.2.0"
+    assert __version__ == version("ke2daira")
 
 
 def test_matsudaira_ken() -> None:


### PR DESCRIPTION
## Summary
- derive ke2daira.__version__ from installed package metadata
- remove the duplicated hard-coded version string from the package
- assert the exposed version matches distribution metadata in tests