### PR TITLE
Migrate Ruff lint settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,11 @@ ruff = "^0.14.3"
 strict = true
 
 [tool.ruff]
+target-version = "py39"
+
+[tool.ruff.lint]
 select = ["ALL"]
 ignore = ["D"]
-target-version = "py39"
 
 [tool.poetry]
 requires-poetry = ">=2.1"


### PR DESCRIPTION
## Summary
- move deprecated Ruff top-level lint settings into tool.ruff.lint
- keep the existing rule selection and ignores unchanged
- remove the deprecation warning from the quality checks