### PR TITLE
Sync README development commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ print(ke2dairanize("松平 健")) # "ケツダイラ マン"
 Install dependencies with poetry: `poetry install` \
 Run type check: `poetry run mypy .` \
 Run tests: `poetry run pytest` \
-Format code: `poetry run black .` \
+Format code: `poetry run ruff format .` \
 Lint and fix code: `poetry run ruff check --fix .`
 
 


### PR DESCRIPTION
## Summary
- replace the outdated black command with the Ruff formatter command
- keep the documented development workflow aligned with the tools in pyproject.toml
- remove a stale setup instruction so contributors can follow the README as-is