### PR TITLE
Adopt PyPI trusted publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -8,8 +8,13 @@ on:
       - "*.*.*"
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/ke2daira
+    permissions:
+      id-token: write
 
     steps:
     - uses: actions/checkout@v5
@@ -23,28 +28,6 @@ jobs:
       run: poetry sync
     - name: Build package
       run: poetry build
-    - name: Upload distributions
-      uses: actions/upload-artifact@v4
-      with:
-        name: release-dists
-        path: dist/
-
-  publish:
-    needs:
-      - build
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/ke2daira
-    permissions:
-      id-token: write
-
-    steps:
-    - name: Download distributions
-      uses: actions/download-artifact@v5
-      with:
-        name: release-dists
-        path: dist/
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,19 +1,14 @@
-# This workflows will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# Build distributions with Poetry and publish them to PyPI via trusted publishing.
 
-name: Upload Python Package
+name: Publish Python Package
 
 on:
   push:
     tags:
       - "*.*.*"
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
-  deploy:
-
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -28,8 +23,29 @@ jobs:
       run: poetry sync
     - name: Build package
       run: poetry build
+    - name: Upload distributions
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-dists
+        path: dist/
+
+  publish:
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/ke2daira
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download distributions
+      uses: actions/download-artifact@v5
+      with:
+        name: release-dists
+        path: dist/
     - name: Publish to PyPI
-      if: startsWith(github.ref, 'refs/tags/')
-      run: poetry publish
-      env:
-        POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: dist/


### PR DESCRIPTION
## Summary
- switch the release workflow from Poetry token publishing to PyPI trusted publishing
- split build and publish into separate jobs and pass dist/ via artifacts
- publish from a dedicated GitHub Actions environment named pypi