### PR TITLE
Automate safe Dependabot merges

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -23,8 +23,16 @@ jobs:
       with:
         github-token: ${{ github.token }}
 
+    - name: Create GitHub App token
+      if: contains(fromJSON('["version-update:semver-patch", "version-update:semver-minor"]'), steps.metadata.outputs.update-type) && steps.metadata.outputs.maintainer-changes != 'true'
+      id: app-token
+      uses: actions/create-github-app-token@v3
+      with:
+        app-id: ${{ vars.APP_ID }}
+        private-key: ${{ secrets.PRIVATE_KEY }}
+
     - name: Enable auto-merge for safe updates
       if: contains(fromJSON('["version-update:semver-patch", "version-update:semver-minor"]'), steps.metadata.outputs.update-type) && steps.metadata.outputs.maintainer-changes != 'true'
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
       run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,30 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  enable-automerge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+    - name: Fetch Dependabot metadata
+      id: metadata
+      uses: dependabot/fetch-metadata@v2
+      with:
+        github-token: ${{ github.token }}
+
+    - name: Enable auto-merge for safe updates
+      if: contains(fromJSON('["version-update:semver-patch", "version-update:semver-minor"]'), steps.metadata.outputs.update-type) && steps.metadata.outputs.maintainer-changes != 'true'
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"


### PR DESCRIPTION
## Summary
- add a pull_request_target workflow for Dependabot PRs
- enable auto-merge only for patch and minor dependency updates without maintainer changes
- rely on branch protection and CI checks before the merge actually lands